### PR TITLE
Canvas App Fixes

### DIFF
--- a/AzureMapsGrid/AzureMapsGrid/AzureMapsGridControl/Other/Solution.xml
+++ b/AzureMapsGrid/AzureMapsGrid/AzureMapsGridControl/Other/Solution.xml
@@ -6,7 +6,7 @@
       <LocalizedName description="AzureMapsGridControl" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0.194</Version>
+    <Version>1.0.195</Version>
     <Managed>2</Managed>
     <Publisher>
       <UniqueName>raw</UniqueName>

--- a/AzureMapsGrid/AzureMapsGrid/ControlManifest.Input.xml
+++ b/AzureMapsGrid/AzureMapsGrid/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest>
-  <control namespace="RAW.AzureMapsGrid" constructor="AzureMapsGrid" version="0.0.252" display-name-key="Azure Maps Grid" description-key="AzureMapsGrid description" control-type="standard" preview-image="preview.png">
+  <control namespace="RAW.AzureMapsGrid" constructor="AzureMapsGrid" version="0.0.253" display-name-key="Azure Maps Grid" description-key="AzureMapsGrid description" control-type="standard">
     <!-- dataset node represents a set of entity records on CDS; allow more than one datasets -->
     <data-set name="mapDataSet" display-name-key="Map Data Set">
     </data-set>

--- a/AzureMapsGrid/AzureMapsGrid/index.ts
+++ b/AzureMapsGrid/AzureMapsGrid/index.ts
@@ -74,8 +74,9 @@ export class AzureMapsGrid implements ComponentFramework.StandardControl<IInputs
 	 */
 	public updateView(context: ComponentFramework.Context<IInputs>): void
 	{	
-		var self = this;
 		var dataSet = context.parameters.mapDataSet;				
+
+		if (dataSet.loading) return;
 
 		//if data set has additional pages retrieve them before running anything else
 		if (dataSet.paging.hasNextPage) {

--- a/BingMapsGrid/BingMapsGrid/BingMapsGridControl/Other/Solution.xml
+++ b/BingMapsGrid/BingMapsGrid/BingMapsGridControl/Other/Solution.xml
@@ -8,7 +8,7 @@
       <LocalizedName description="BingMapsGridControl" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0.76</Version>
+    <Version>1.0.96</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>

--- a/BingMapsGrid/BingMapsGrid/ControlManifest.Input.xml
+++ b/BingMapsGrid/BingMapsGrid/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest>
-  <control namespace="RAW.BingMapsGrid" constructor="BingMapsGrid" version="0.0.81" display-name-key="Bing Maps Grid" description-key="BingMapsGrid description" control-type="standard" preview-image="preview.png">
+  <control namespace="RAW.BingMapsGrid" constructor="BingMapsGrid" version="0.0.101" display-name-key="Bing Maps Grid" description-key="BingMapsGrid description" control-type="standard">
     <!-- dataset node represents a set of entity records on CDS; allow more than one datasets -->
     <data-set name="mapDataSet" display-name-key="Map Data Set">
     </data-set>

--- a/BingMapsGrid/BingMapsGrid/css/BingMapsGrid.css
+++ b/BingMapsGrid/BingMapsGrid/css/BingMapsGrid.css
@@ -5,7 +5,7 @@
 #mapDiv {
     position:relative;
     width:100%;
-    height:calc(100% - 25px);
+    /* height:calc(100% - 25px); */
     border-style: solid;
     margin:auto;    
     z-index:0; /* z-index of 0 will ensure that our map controls dont overlap the dyanmics drop downs. */

--- a/DetailListGrid/DetailListGrid/ControlManifest.Input.xml
+++ b/DetailListGrid/DetailListGrid/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest>
-  <control namespace="RAW.DetailListGrid" constructor="DetailListGrid" version="0.0.112" display-name-key="DetailsList Grid" description-key="A custom grid view that utilizes the Office Fabric UI DetailsList control." control-type="standard">
+  <control namespace="RAW.DetailListGrid" constructor="DetailListGrid" version="0.0.122" display-name-key="DetailsList Grid" description-key="A custom grid view that utilizes the Office Fabric UI DetailsList control." control-type="standard">
     <!-- dataset node represents a set of entity records on CDS; allow more than one datasets -->
     <data-set name="sampleDataSet" display-name-key="Dataset_Display_Key" cds-data-set-options="displayCommandBar:true;displayViewSelector:true;displayQuickFindSearch:true">
       <!-- 'property-set' node represents a unique, configurable property that each record in the dataset must provide. -->

--- a/DetailListGrid/DetailListGrid/DetailListGridControl/Other/Solution.xml
+++ b/DetailListGrid/DetailListGrid/DetailListGridControl/Other/Solution.xml
@@ -8,7 +8,7 @@
       <LocalizedName description="DetailListGridControl" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0.109</Version>
+    <Version>1.0.108</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>

--- a/DetailListGrid/DetailListGrid/index.ts
+++ b/DetailListGrid/DetailListGrid/index.ts
@@ -45,11 +45,21 @@ export class DetailListGrid implements ComponentFramework.StandardControl<IInput
 		this._detailList.setAttribute("id", "detailList");
 		// if data-is-scrollable is not set then grid will not show all results.
 		this._detailList.setAttribute("data-is-scrollable", "true");
-		// sets the height based upon the rowSpan which is there but not included in the Mode interace when
-		// the control is a subgrid.
-		// Then multiple by 1.5 em which is what MS uses per row.	
-		let rowspan = (this._context.mode as any).rowSpan;
-		if (rowspan) this._detailList.style.height = `${(rowspan * 1.5).toString()}em`;
+		
+		//we need to set the grid height.  If the allocated height is not -1 then we are in a canvas app 
+		//and we need to set the heigh based upon the allocated height of the container.
+		if (this._context.mode.allocatedHeight !== -1)
+		{
+			this._detailList.style.height = `${(this._context.mode.allocatedHeight).toString()}px`
+		}
+		else
+		{
+			// sets the height based upon the rowSpan which is there but not included in the Mode interace when
+			// the control is a subgrid.
+			// Then multiple by 1.5 em which is what MS uses per row.	
+			let rowspan = (this._context.mode as any).rowSpan;
+			if (rowspan) this._detailList.style.height = `${(rowspan * 1.5).toString()}em`;
+		}
 
 		this._container.appendChild(this._detailList);
 
@@ -64,8 +74,16 @@ export class DetailListGrid implements ComponentFramework.StandardControl<IInput
 	 */
 	public updateView(context: ComponentFramework.Context<IInputs>): void
 	{
-		var self = this;
-		var dataSet = context.parameters.sampleDataSet; 			
+		var dataSet = context.parameters.sampleDataSet;
+		
+		//reset the height if we are in a canvas app
+		//currently though the dataset in canvas will not return the columns so this component will not load correctly in canvas.
+		if (this._context.mode.allocatedHeight !== -1)
+		{
+			this._detailList.style.height = `${(this._context.mode.allocatedHeight).toString()}px`
+		}
+
+		if (dataSet.loading) return;
 
 		//if data set has additional pages retrieve them before running anything else
 		if (dataSet.paging.hasNextPage) {


### PR DESCRIPTION
-Fixed Issue when dataset.loading return was removed.  Large datasets were not completely loading.
-Remove preview-image from manifest files because it causes components to not import into Canvas App.
-Set sizing for controls based upon them being in Canvas/Model app.

Current Canvas Compatibility
-Color Picker: Works
-Bing Maps Control: Loads but there appear to be issues when interacting with the map.
-Details List Grid: Control can be imported and will load but currently the datasets in Canvas app do not include the columns from the view so the grid will not load.