### PR TITLE
Dutch

### DIFF
--- a/Calendar/Calendar/CalendarControl.tsx
+++ b/Calendar/Calendar/CalendarControl.tsx
@@ -53,8 +53,8 @@ React.useEffect(()=>{
 
 //allows for changing the calendar date if a date/time field is utilized in canvas on the input parameters
 React.useEffect(()=>{
-    if (props.pcfContext.parameters.calendarDate.raw && calendarDate != props.pcfContext.parameters.calendarDate.raw){
-        setCalendarDate(props.pcfContext.parameters.calendarDate.raw)
+    if (props.pcfContext.parameters.calendarDate?.raw?.getTime() !== 0 && calendarDate != props.pcfContext.parameters.calendarDate.raw){
+        setCalendarDate(props.pcfContext.parameters.calendarDate.raw as Date)
     }    
 },[props.pcfContext.parameters.calendarDate.raw])
 

--- a/Calendar/Calendar/CalendarControl/Other/Solution.xml
+++ b/Calendar/Calendar/CalendarControl/Other/Solution.xml
@@ -8,7 +8,7 @@
       <LocalizedName description="CalendarControl" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0.137</Version>
+    <Version>1.0.139</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>

--- a/Calendar/Calendar/ControlManifest.Input.xml
+++ b/Calendar/Calendar/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest>
-  <control namespace="RAW.Calendar" constructor="Calendar" version="0.0.140" display-name-key="Calendar" description-key="A Calendar view that can be used in both Model and Canvas apps. Ensure that any fields you define in the parameters are included in your view in a Model App or in your Collection in a Canvas app." control-type="standard">
+  <control namespace="RAW.Calendar" constructor="Calendar" version="0.0.142" display-name-key="Calendar" description-key="A Calendar view that can be used in both Model and Canvas apps. Ensure that any fields you define in the parameters are included in your view in a Model App or in your Collection in a Canvas app." control-type="standard">
     <data-set name="calendarDataSet" display-name-key="Calendar Data" cds-data-set-options="displayCommandBar:true;displayViewSelector:true;displayQuickFind:false">
     </data-set>
     <property name="eventFieldName" display-name-key="Event Name Field" description-key="Enter the Event Name Field schema name which will be used to display on the calendar. For related entities use the following format (new_entityname.new_fieldname)" of-type="SingleLine.Text" usage="input" required="true" default-value="name" />

--- a/Calendar/Calendar/Translations.tsx
+++ b/Calendar/Calendar/Translations.tsx
@@ -99,6 +99,25 @@ export default function GetMessages(lang: string): Messages{
             agenda: 'Повестка дня',
             noEventsInRange: 'В этом диапазоне нет событий.',
             showMore: total => `Еще +${total} события`
+            }
+        case 'nl':
+            return {
+                date: 'Datum',
+                time: 'Tijdstip',
+                event: 'Evenement',
+                allDay: 'De hele dag',
+                week: 'Week',
+                work_week: 'Werk Week',
+                day: 'Dag',
+                month: 'Maand',
+                previous: 'Terug',
+                next: 'Naast',
+                yesterday: 'Gisteren',
+                tomorrow: 'Morgen',
+                today: 'Vandaag',
+                agenda: 'Agenda',              
+                noEventsInRange: 'Er zijn geen evenementen gepland in deze periode.',              
+                showMore: total => `+${total} meer`
             }        
         case 'en':
         default:


### PR DESCRIPTION
-Added Dutch Language support for CalendarControl, thanks @ArtKamp Closes #34
-Updated Readme for Calendar Control to reflect having to utilize collections for Canvas Apps Closes #35
-Fixed Bug in Canvas app that was defaulting calendar to 1969 when no calendarDate property was supplied.  Closes #36 