### PR TITLE
Calendar Control from Art's feedback.

### DIFF
--- a/Calendar/Calendar/CalendarControl/Other/Solution.xml
+++ b/Calendar/Calendar/CalendarControl/Other/Solution.xml
@@ -8,7 +8,7 @@
       <LocalizedName description="CalendarControl" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0.139</Version>
+    <Version>1.0.143</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>

--- a/Calendar/Calendar/ControlManifest.Input.xml
+++ b/Calendar/Calendar/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest>
-  <control namespace="RAW.Calendar" constructor="Calendar" version="0.0.142" display-name-key="Calendar" description-key="A Calendar view that can be used in both Model and Canvas apps. Ensure that any fields you define in the parameters are included in your view in a Model App or in your Collection in a Canvas app." control-type="standard">
+  <control namespace="RAW.Calendar" constructor="Calendar" version="0.0.146" display-name-key="Calendar" description-key="A Calendar view that can be used in both Model and Canvas apps. Ensure that any fields you define in the parameters are included in your view in a Model App or in your Collection in a Canvas app." control-type="standard">
     <data-set name="calendarDataSet" display-name-key="Calendar Data" cds-data-set-options="displayCommandBar:true;displayViewSelector:true;displayQuickFind:false">
     </data-set>
     <property name="eventFieldName" display-name-key="Event Name Field" description-key="Enter the Event Name Field schema name which will be used to display on the calendar. For related entities use the following format (new_entityname.new_fieldname)" of-type="SingleLine.Text" usage="input" required="true" default-value="name" />
@@ -21,7 +21,8 @@
     <property name="currentRangeStart" display-name-key="(Output) Calendar Range Start" description-key="When the current calendar range changes the new Start will be returned." usage="output" of-type="DateAndTime.DateAndTime" required="false" />
     <property name="currentRangeEnd" display-name-key="(Output) Calendar Range End" description-key="When the current calendar range changes the new End will be returned." usage="output" of-type="DateAndTime.DateAndTime" required="false" />
     <property name="currentCalendarDate" display-name-key="(Output) Calendar Date" description-key="Provides the current date the calendar is set to." usage="output" of-type="DateAndTime.DateOnly" required="false" />
-    <property name="onChangeAction" display-name-key="(Output) On Change Action" description-key="This will provide which action was taken for an OnChange Event" usage="output" of-type="SingleLine.Text" required="false" />
+    <property name="actionSlotSelected" display-name-key="(Output) Empty Time Slot Was Selected" description-key="Provides the Canvas app producer notification that an empty time slot was selected on the calendar." usage="output" of-type="TwoOptions" required="false" />
+    <property name="actionRecordSelected" display-name-key="(Output) Record was selected" description-key="Provides the Canvas app producer notification that a record was selected on the calendar." usage="output" of-type="TwoOptions" required="false" />
     <resources>
       <code path="index.ts" order="1" />
       <css path="css/react-big-calendar.css" order="1" />


### PR DESCRIPTION
Calendar Control Update
-Fixed issue where Hex colors would not display if you were not using Resources on the Calendar
-Added the following output variables.  
* actionSlotSelected: this will fire when someone selects and empty time slot
* actionRecordSelected: this will fire when a record is selected
-Removed the following output variable
* onChangeAction: this was giving you the action that had been taken such as an empty time slot being selected and such but due to the async nature of PCF this was not a workable solution
-Fixed issue in model app version where not entering a Resource Name field would cause issues.