### PR TITLE
Calendar Control Updated Date Field on Agenda to Transparent

### DIFF
--- a/Calendar/Calendar/CalendarControl.tsx
+++ b/Calendar/Calendar/CalendarControl.tsx
@@ -45,6 +45,22 @@ const [calendarDate, setCalendarDate] = React.useState(props.pcfContext.paramete
 const [calendarScrollTo, setCalendarScrollTo] = React.useState(moment().set({"hour": props.pcfContext.parameters.calendarScrollToTime?.raw || 0, "minute": 0, "seconds" : 0}).toDate());
 const calendarRef = React.useRef(null);
 
+//fix for agenda color issue
+React.useEffect(()=> {
+    if (calendarView === 'agenda')
+    {
+        var agendaTRs = document.querySelectorAll(':scope .rbc-agenda-content .rbc-agenda-table tr');
+        for (var i=0; i < agendaTRs.length; i++)
+        {    
+                var agendaTR = agendaTRs[i] as HTMLTableRowElement
+                var backgroundColor = agendaTR.style.backgroundColor;
+                agendaTR.style.backgroundColor = "transparent";
+                (agendaTR.getElementsByClassName('rbc-agenda-time-cell')[0] as HTMLTableCellElement).style.backgroundColor = backgroundColor;
+                (agendaTR.getElementsByClassName('rbc-agenda-event-cell')[0] as HTMLTableCellElement).style.backgroundColor = backgroundColor;
+        }
+    }
+}, [calendarView])
+
 //sets the keys and calendar data when the control is loaded or the calendarDataSet changes.
 React.useEffect(()=>{
     async function asyncCalendarData(){

--- a/Calendar/Calendar/CalendarControl/Other/Solution.xml
+++ b/Calendar/Calendar/CalendarControl/Other/Solution.xml
@@ -8,7 +8,7 @@
       <LocalizedName description="CalendarControl" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0.147</Version>
+    <Version>1.0.148</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>

--- a/Calendar/Calendar/ControlManifest.Input.xml
+++ b/Calendar/Calendar/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest>
-  <control namespace="RAW.Calendar" constructor="Calendar" version="0.0.150" display-name-key="Calendar" description-key="A Calendar view that can be used in both Model and Canvas apps. Ensure that any fields you define in the parameters are included in your view in a Model App or in your Collection in a Canvas app." control-type="standard">
+  <control namespace="RAW.Calendar" constructor="Calendar" version="0.0.151" display-name-key="Calendar" description-key="A Calendar view that can be used in both Model and Canvas apps. Ensure that any fields you define in the parameters are included in your view in a Model App or in your Collection in a Canvas app." control-type="standard">
     <data-set name="calendarDataSet" display-name-key="Calendar Data" cds-data-set-options="displayCommandBar:true;displayViewSelector:true;displayQuickFind:false">
     </data-set>
     <property name="eventFieldName" display-name-key="Event Name Field" description-key="Enter the Event Name Field schema name which will be used to display on the calendar. For related entities use the following format (new_entityname.new_fieldname)" of-type="SingleLine.Text" usage="input" required="true" default-value="name" />


### PR DESCRIPTION
Calendar Control
-Set the date field on the Agenda view to be transparent.

Note: This is a bit hacky because i wasn't able to NPM the fork i made from react-big-calendar.  So this implementation is using javascript with a useEffect. This means that you will possibly see color in the Date field for a very short amount of time as the Agenda view loads.

Close #42 