### PR TITLE
Added Pin Clustering

### DIFF
--- a/BingMapsGrid/BingMapsGrid/BingMapsGridControl/Other/Solution.xml
+++ b/BingMapsGrid/BingMapsGrid/BingMapsGridControl/Other/Solution.xml
@@ -8,7 +8,7 @@
       <LocalizedName description="BingMapsGridControl" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0.96</Version>
+    <Version>1.0.102</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>

--- a/BingMapsGrid/BingMapsGrid/ControlManifest.Input.xml
+++ b/BingMapsGrid/BingMapsGrid/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest>
-  <control namespace="RAW.BingMapsGrid" constructor="BingMapsGrid" version="0.0.101" display-name-key="Bing Maps Grid" description-key="BingMapsGrid description" control-type="standard">
+  <control namespace="RAW.BingMapsGrid" constructor="BingMapsGrid" version="0.0.108" display-name-key="Bing Maps Grid" description-key="BingMapsGrid description" control-type="standard">
     <!-- dataset node represents a set of entity records on CDS; allow more than one datasets -->
     <data-set name="mapDataSet" display-name-key="Map Data Set">
     </data-set>
@@ -10,6 +10,13 @@
     <property name="longFieldName" display-name-key="Longitude Field" description-key="Enter the Latitude field schema name. For related entities use the following format (new_entityname.new_fieldname)." of-type="SingleLine.Text" usage="input" required="true" default-value="address1_longitude" />
     <property name="pushpinColorField" display-name-key="Pushpin Color Field" description-key="Enter the Pushpin Color field schema name if available, this field should contain a hex value for the color." of-type="SingleLine.Text" usage="input" required="false" default-value="" />
     <property name="defaultPushpinColor" display-name-key="Default Pushpin Color" description-key="Enter a hex value for the default color of the Pushpins(example: #ffffff)." of-type="SingleLine.Text" usage="input" required="false" default-value="" />
+    <property name="clusteringEnabled" display-name-key="Clustering Enabled" description-key="Enable clustering on the calendar (true or false)." of-type="SingleLine.Text" usage="input" required="true" default-value="false" />
+    <property name="clusterPlacement" display-name-key="Cluster Placement" description-key="Determines the output type that the file uploader will return." of-type="Enum" usage="input" required="true" default-value="MeanAverage">
+      <value name="MeanAverage" display-name-key="Mean Average" description-key="Mean Average placement calculates the average position of a group of coordinates. This method creates a more realistic representation of the data, however requires more processing power and increases the chances of pushpins overlapping.">MeanAverage</value>
+      <value name="FirstLocation" display-name-key="FirstLocation" description-key="This method is the simplest way to represent a cluster. It places the cluster at the first location in the cluster. This method may not accurately represent the data but requires little processing power.">FirstLocation</value>
+    </property>
+    <property name="clusterGridSize" display-name-key="Cluster Grid Size" description-key="The width and height of the gird cells used for clustering in pixels. Default: 45." of-type="Whole.None" usage="input" required="false" default-value="45" />
+    <property name="clusterPushpinColor" display-name-key="Cluster Pushpin Color" description-key="Enter a hex value for the color of the cluster Pushpins(example: #ffffff)." of-type="SingleLine.Text" usage="input" required="false" default-value="" />
     <property name="bingMapsAPIKey" display-name-key="Bing Maps API Key" description-key="Enter your Bing Maps API Key." of-type="SingleLine.Text" usage="input" required="true" />
     <resources>
       <code path="index.ts" order="1" />

--- a/BingMapsGrid/package-lock.json
+++ b/BingMapsGrid/package-lock.json
@@ -2990,6 +2990,11 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "hex-color-regex": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.0.3.tgz",
+      "integrity": "sha1-IXVpO8KS/gZxGwT67pAEeQkm+bA="
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -3213,6 +3218,14 @@
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
+      }
+    },
+    "is-hexcolor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-hexcolor/-/is-hexcolor-1.0.0.tgz",
+      "integrity": "sha1-SV/uGhK6rwCcECp5m97DGTIRJ0o=",
+      "requires": {
+        "hex-color-regex": "~1.0.2"
       }
     },
     "is-number": {

--- a/BingMapsGrid/package.json
+++ b/BingMapsGrid/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@types/node": "^10.17.24",
     "@types/powerapps-component-framework": "^1.2.3",
+    "is-hexcolor": "^1.0.0",
     "spin.js": "^4.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Added the following properties to the component to allow for Pin Clustering

- Clustering Enabled (Text) - Set to true or false
- Clustering Placement (Enum) - Mean Average or First Location [See Definitions](https://docs.microsoft.com/en-us/bingmaps/v8-web-control/modules/clustering-module/clusterplacementtype-enumeration)
- Cluster Grid Size (Number) - The width and height of the gird cells used for clustering in pixels
- Cluster Pushpin Color - Set the color to a hex value to distinguish the difference between a cluster pin and a regular pin.  If you don't set it the default with be the default pin color.

Fixed issue were calendar layers were loaded multiple times due to updateView firing twice.