### PR TITLE
Bing Maps Added Entity Type Property

### DIFF
--- a/BingMapsGrid/BingMapsGrid/BingMapsGridControl/Other/Solution.xml
+++ b/BingMapsGrid/BingMapsGrid/BingMapsGridControl/Other/Solution.xml
@@ -8,7 +8,7 @@
       <LocalizedName description="BingMapsGridControl" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0.111</Version>
+    <Version>1.0.113</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>

--- a/BingMapsGrid/BingMapsGrid/ControlManifest.Input.xml
+++ b/BingMapsGrid/BingMapsGrid/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest>
-  <control namespace="RAW.BingMapsGrid" constructor="BingMapsGrid" version="0.0.116" display-name-key="Bing Maps Grid" description-key="BingMapsGrid description" control-type="standard">
+  <control namespace="RAW.BingMapsGrid" constructor="BingMapsGrid" version="0.0.118" display-name-key="Bing Maps Grid" description-key="BingMapsGrid description" control-type="standard">
     <!-- dataset node represents a set of entity records on CDS; allow more than one datasets -->
     <data-set name="mapDataSet" display-name-key="Map Data Set">
     </data-set>
@@ -9,6 +9,7 @@
     <property name="latFieldName" display-name-key="Latitude Field" description-key="Enter the Latitude field schema name. For related entities use the following format (new_entityname.new_fieldname)" of-type="SingleLine.Text" usage="input" required="true" default-value="address1_latitude" />
     <property name="longFieldName" display-name-key="Longitude Field" description-key="Enter the Latitude field schema name. For related entities use the following format (new_entityname.new_fieldname)." of-type="SingleLine.Text" usage="input" required="true" default-value="address1_longitude" />
     <property name="idFieldName" display-name-key="Id Field" description-key="For Model Apps this is not required but if you are using Canvas you will need to put in the Id field for the item if you are using a collection." of-type="SingleLine.Text" usage="input" required="false" />
+    <property name="recordTypeFieldName" display-name-key="Record Type Field" description-key="For Model Apps this is not required but if you are using Canvas you will need to put in the Type field for the item if you are using a collection.  This can be helpful when you have a mix of entities in the collection such as Account and Contacts." of-type="SingleLine.Text" usage="input" required="false" />
     <property name="pushpinColorField" display-name-key="Pushpin Color Field" description-key="Enter the Pushpin Color field schema name if available, this field should contain a hex value for the color." of-type="SingleLine.Text" usage="input" required="false" default-value="" />
     <property name="defaultPushpinColor" display-name-key="Default Pushpin Color" description-key="Enter a hex value for the default color of the Pushpins(example: #ffffff)." of-type="SingleLine.Text" usage="input" required="false" default-value="" />
     <property name="clusteringEnabled" display-name-key="Clustering Enabled" description-key="Enable clustering on the calendar (true or false)." of-type="SingleLine.Text" usage="input" required="true" default-value="false" />
@@ -20,6 +21,7 @@
     <property name="clusterPushpinColor" display-name-key="Cluster Pushpin Color" description-key="Enter a hex value for the color of the cluster Pushpins(example: #ffffff)." of-type="SingleLine.Text" usage="input" required="false" default-value="" />
     <property name="bingMapsAPIKey" display-name-key="Bing Maps API Key" description-key="Enter your Bing Maps API Key." of-type="SingleLine.Text" usage="input" required="true" />
     <property name="selectedRecordId" display-name-key="(Output) Selected Record Id" description-key="When a pin is selected this will be updated." usage="output" of-type="SingleLine.Text" required="false" />
+    <property name="selectedRecordType" display-name-key="(Output) Selected Record Type" description-key="When a pin is selected this will be updated." usage="output" of-type="SingleLine.Text" required="false" />
     <resources>
       <code path="index.ts" order="1" />
       <css path="css/BingMapsGrid.css" order="1" />

--- a/BingMapsGrid/BingMapsGrid/index.ts
+++ b/BingMapsGrid/BingMapsGrid/index.ts
@@ -35,6 +35,7 @@ export class BingMapsGrid implements ComponentFramework.StandardControl<IInputs,
 	private _context: ComponentFramework.Context<IInputs>;
 	private _updateFromOutput: boolean;
 	private _selectedRecordId: string;
+	private _selectedRecordType: string;
 
 		
 	constructor()
@@ -61,6 +62,7 @@ export class BingMapsGrid implements ComponentFramework.StandardControl<IInputs,
 		this._bMapIsLoaded = false;
 		this._bMapScriptIsLoaded = false;
 		this._selectedRecordId = '';
+		this._selectedRecordType = '';
 		
 		this._loadingSpinner = new Spinner({
 			length: 0, 
@@ -188,6 +190,7 @@ export class BingMapsGrid implements ComponentFramework.StandardControl<IInputs,
 
 		var keys = { 
 			id: params?.idFieldName?.raw ? self.getFieldName(dataSet, params.idFieldName.raw) : "",
+			recordType: params?.recordTypeFieldName?.raw ? self.getFieldName(dataSet, params.recordTypeFieldName.raw) : "",
 			lat: params?.latFieldName?.raw ? self.getFieldName(dataSet, params.latFieldName.raw) : "",
 			long: params?.longFieldName?.raw ? self.getFieldName(dataSet, params.longFieldName.raw) : "",
 			name: params?.primaryFieldName?.raw ? self.getFieldName(dataSet, params.primaryFieldName.raw) : "",
@@ -234,7 +237,7 @@ export class BingMapsGrid implements ComponentFramework.StandardControl<IInputs,
 				title: name,
 				description: keys.description && record.getValue(keys.description) ? record.getValue(keys.description) : "",
 				entityId: keys.id && record.getValue(keys.id) ? record.getValue(keys.id) : recordId, 
-				entityName: dataSet.getTargetEntityType()
+				entityName: keys.recordType && record.getValue(keys.recordType) ? record.getValue(keys.recordType) : dataSet.getTargetEntityType()
 			};			
 
 			//set color
@@ -341,6 +344,7 @@ export class BingMapsGrid implements ComponentFramework.StandardControl<IInputs,
 						{
 							self._context.navigation.openForm({openInNewWindow: true, entityId: e.target.metadata.entityId, entityName: e.target.metadata.entityName })
 						}
+						self._selectedRecordType = e.target.metadata.entityName;
 						self._selectedRecordId = e.target.metadata.entityId;
 						self._notifyOutputChanged();
 					}
@@ -409,7 +413,8 @@ export class BingMapsGrid implements ComponentFramework.StandardControl<IInputs,
 		let notifyAgain = false;
 
 		return {
-			selectedRecordId: this._selectedRecordId || ''
+			selectedRecordId: this._selectedRecordId || '',
+			selectedRecordType: this._selectedRecordType || ''
 		};
 	}
 

--- a/WorldDaylightMap/Solution/RAWWorldDaylightMap/src/Other/Solution.xml
+++ b/WorldDaylightMap/Solution/RAWWorldDaylightMap/src/Other/Solution.xml
@@ -8,7 +8,7 @@
       <LocalizedName description="RAWWorldDaylightMap" languagecode="1033" />
     </LocalizedNames>
     <Descriptions />
-    <Version>1.0.4</Version>
+    <Version>1.0.6</Version>
     <!-- Solution Package Type: Unmanaged(0)/Managed(1)/Both(2)-->
     <Managed>2</Managed>
     <Publisher>

--- a/WorldDaylightMap/WorldDaylightMap/ControlManifest.Input.xml
+++ b/WorldDaylightMap/WorldDaylightMap/ControlManifest.Input.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest>
-  <control namespace="RAW" constructor="WorldDaylightMap" version="0.0.6" display-name-key="RAW! World Daylight Map" description-key="Enables you to embed a map of the world with a daylight/night-time overlay." control-type="standard" preview-image="img/preview.png">
+  <control namespace="RAW" constructor="WorldDaylightMap" version="0.0.8" display-name-key="RAW! World Daylight Map" description-key="Enables you to embed a map of the world with a daylight/night-time overlay." control-type="standard" preview-image="img/preview.png">
     <!-- <data-set name="iconDataSet" display-name-key="Icon Data Set" description-key="Allows you to define a collection of icons on the map.">
     </data-set> -->
     <property name="controlsPosition" display-name-key="Controls Position" description-key="The position of the control on the map." of-type="Enum" usage="input" required="true" default-value="outer-top">


### PR DESCRIPTION
Add additional property to control to allow user to enter the entity type name in a canvas app when they are utilizing more than one entity within the map.  Eg. Accounts and Contacts both show in the map.