### PR TITLE
fix: add minimum width to timeslot group for better layout

### DIFF
--- a/Calendar/Calendar/css/react-big-calendar.override.css
+++ b/Calendar/Calendar/css/react-big-calendar.override.css
@@ -116,6 +116,10 @@
   border-color: rgb(var(--calendar-border-color)) !important;
 }
 
+.rbc-timeslot-group {
+  min-width: 70px !important;
+}
+
 .rbc-event:focus,
 .rbc-toolbar button:focus {
   outline: 5px auto rgb(var(--calendar-border-color)) !important;


### PR DESCRIPTION
This pull request includes a minor styling update to the `react-big-calendar.override.css` file. The change ensures that `.rbc-timeslot-group` elements have a minimum width of 70 pixels for better layout consistency.

Closes #336 