### PR TITLE
Fix Scheduler unmount bug

### DIFF
--- a/Scheduler/Scheduler/index.ts
+++ b/Scheduler/Scheduler/index.ts
@@ -172,6 +172,6 @@ export class Scheduler implements ComponentFramework.StandardControl<IInputs, IO
 
     public destroy(): void {
         // Unmount the React app
-        ReactDOM.createRoot(this._container).unmount();
+        this._reactRoot.unmount();
     }
 }


### PR DESCRIPTION
## Summary
- ensure Scheduler control unmounts using the same React root instance

## Testing
- `npm run lint` *(fails: pcf-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656601296883289441afb234e28011