### PR TITLE
Upgrade AzureMapsGrid to Fluent UI React components

### DIFF
--- a/AzureMapsGrid/package.json
+++ b/AzureMapsGrid/package.json
@@ -17,10 +17,9 @@
     "@types/node": "^10.17.24",
     "@types/powerapps-component-framework": "^1.3",
     "azure-maps-control": "^2.0.25",
-    "office-ui-fabric-react": "^7.117.4",
+    "@fluentui/react-components": "^9.59.0",
     "react": "^16.13.1",
-    "react-azure-maps": "0.0.6",
-    "spin.js": "^4.1.0"
+    "react-azure-maps": "1.0.3"
   },
   "devDependencies": {
     "@microsoft/eslint-plugin-power-apps": "^0.2.51",


### PR DESCRIPTION
## Summary
- switch AzureMapsGrid from office-ui-fabric-react to `@fluentui/react-components`
- use Fluent UI Spinner and Popover instead of old components
- update react-azure-maps

## Testing
- `npm run lint` *(passes)*
- `npm run build` *(fails: cannot find module '@fluentui/react-components')*

------
https://chatgpt.com/codex/tasks/task_e_686bc8df28408328869180b020c7b377